### PR TITLE
Create base config module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "equivalent"
@@ -24,15 +48,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "figment"
 version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "649f3e5d826594057e9a519626304d8da859ea8a0b18ce99500c586b8d45faee"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
  "serde_yaml",
+ "tempfile",
  "uncased",
  "version_check",
 ]
@@ -54,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +112,51 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "libc"
+version = "0.2.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pear"
@@ -93,6 +186,7 @@ name = "pod-director"
 version = "0.1.0"
 dependencies = [
  "figment",
+ "indoc",
  "serde",
 ]
 
@@ -128,10 +222,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -167,6 +289,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
 name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +303,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -203,6 +344,72 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,209 @@
 version = 3
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "figment"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649f3e5d826594057e9a519626304d8da859ea8a0b18ce99500c586b8d45faee"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "serde_yaml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "pear"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pod-director"
 version = "0.1.0"
+dependencies = [
+ "figment",
+ "serde",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "serde"
+version = "1.0.190"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.190"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0.190", features = ["derive"] }
+figment = { version = "0.10.12", features = ["env", "yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "pod-director"
 description = "A simple kubernetes utility to make pods in specific namespaces run in specific nodes"
 license = "MIT"
-license-file = "LICENSE"
 repository = "https://github.com/Angelin01/pod-director"
 keywords = ["kubernetes", "pods", "nodes"]
 version = "0.1.0"
@@ -11,3 +10,7 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.190", features = ["derive"] }
 figment = { version = "0.10.12", features = ["env", "yaml"] }
+
+[dev-dependencies]
+figment = { version = "0.10.12", features = ["test"] }
+indoc = "2.0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,15 @@
+use std::collections::HashMap;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Config {
+	groups: HashMap<String, GroupConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GroupConfig {
+	node_selector: Vec<String>,
+	affinity: Vec<String>,
+	tolerations: Vec<String>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,32 @@
 use std::collections::HashMap;
+use figment::{Figment, providers::{Env, Format, Yaml}};
 use serde::Deserialize;
 
-#[derive(Deserialize)]
-struct Config {
+static ENV_PREFIX: &'static str = "PD_";
+static ENV_CONFIG_FILE: &'static str = "PD_CONFIG_FILE";
+static DEFAULT_CONFIG_FILE: &'static str = "./pd-config.yaml";
+
+impl Config {
+	pub fn load() -> Self {
+		let config_file = std::env::var(ENV_CONFIG_FILE).unwrap_or(DEFAULT_CONFIG_FILE.into());
+
+		Figment::new()
+			.merge(Yaml::file(config_file))
+			.merge(Env::prefixed(ENV_PREFIX).split("__"))
+			.extract()
+			.unwrap()
+	}
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
 	groups: HashMap<String, GroupConfig>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct GroupConfig {
-	node_selector: Vec<String>,
-	affinity: Vec<String>,
-	tolerations: Vec<String>,
+	node_selector: Option<Vec<String>>,
+	affinity: Option<Vec<String>>,
+	tolerations: Option<Vec<String>>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use figment::{Figment, error, providers::{Env, Format, Yaml}};
-use serde::Deserialize;
+use figment::providers::Serialized;
+use serde::{Deserialize, Serialize};
 
 static ENV_PREFIX: &'static str = "PD_";
 static ENV_CONFIG_FILE: &'static str = "PD_CONFIG_FILE";
@@ -10,19 +11,27 @@ impl Config {
 	pub fn load() -> error::Result<Self> {
 		let config_file = std::env::var(ENV_CONFIG_FILE).unwrap_or(DEFAULT_CONFIG_FILE.into());
 
-		Figment::new()
+		Figment::from(Serialized::defaults(Config::default()))
 			.merge(Yaml::file(config_file))
 			.merge(Env::prefixed(ENV_PREFIX).split("__"))
 			.extract()
 	}
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+impl Default for Config {
+	fn default() -> Self {
+		Config {
+			groups: HashMap::new(),
+		}
+	}
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct Config {
 	groups: HashMap<String, GroupConfig>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct GroupConfig {
 	node_selector: Option<Vec<String>>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,32 +1,163 @@
 use std::collections::HashMap;
-use figment::{Figment, providers::{Env, Format, Yaml}};
+use figment::{Figment, error, providers::{Env, Format, Yaml}};
 use serde::Deserialize;
 
 static ENV_PREFIX: &'static str = "PD_";
 static ENV_CONFIG_FILE: &'static str = "PD_CONFIG_FILE";
-static DEFAULT_CONFIG_FILE: &'static str = "./pd-config.yaml";
+static DEFAULT_CONFIG_FILE: &'static str = "pd-config.yaml";
 
 impl Config {
-	pub fn load() -> Self {
+	pub fn load() -> error::Result<Self> {
 		let config_file = std::env::var(ENV_CONFIG_FILE).unwrap_or(DEFAULT_CONFIG_FILE.into());
 
 		Figment::new()
 			.merge(Yaml::file(config_file))
 			.merge(Env::prefixed(ENV_PREFIX).split("__"))
 			.extract()
-			.unwrap()
 	}
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct Config {
 	groups: HashMap<String, GroupConfig>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct GroupConfig {
 	node_selector: Option<Vec<String>>,
 	affinity: Option<Vec<String>>,
 	tolerations: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::HashMap;
+	use figment::Jail;
+	use indoc::indoc;
+	use super::{Config, DEFAULT_CONFIG_FILE, ENV_CONFIG_FILE, GroupConfig};
+
+	#[test]
+	fn given_valid_config_file_at_default_path_then_should_be_loaded() {
+		Jail::expect_with(|jail| {
+			jail.create_file(DEFAULT_CONFIG_FILE, indoc! { r#"
+				groups:
+				  foo:
+				    nodeSelector: ["a", "b", "c"]
+				  bar:
+				    tolerations: ["1", "2"]
+				  bazz:
+				    affinity: []
+				  all:
+				    nodeSelector: ["a", "b", "c"]
+				    tolerations: ["1", "2"]
+				    affinity: []
+			"# })?;
+
+			let config = Config::load()?;
+
+			let mut groups = HashMap::new();
+			groups.insert("foo".into(), GroupConfig {
+				node_selector: Some(vec!["a".into(), "b".into(), "c".into()]),
+				affinity: None,
+				tolerations: None,
+			});
+			groups.insert("bar".into(), GroupConfig {
+				node_selector: None,
+				affinity: None,
+				tolerations: Some(vec!["1".into(), "2".into()]),
+			});
+			groups.insert("bazz".into(), GroupConfig {
+				node_selector: None,
+				affinity: Some(vec![]),
+				tolerations: None,
+			});
+			groups.insert("all".into(), GroupConfig {
+				node_selector: Some(vec!["a".into(), "b".into(), "c".into()]),
+				affinity: Some(vec![]),
+				tolerations: Some(vec!["1".into(), "2".into()]),
+			});
+
+			assert_eq!(config, Config { groups });
+
+			Ok(())
+		});
+	}
+
+	#[test]
+	fn given_different_file_path_by_env_var_should_load_correct_file() {
+		Jail::expect_with(|jail| {
+			jail.create_file(DEFAULT_CONFIG_FILE, indoc! { r#"
+				groups:
+				  foo:
+				    nodeSelector: []
+			"# })?;
+
+			jail.create_file("other-config-file.yaml", indoc! { r#"
+				groups:
+				  bar:
+				    nodeSelector: ["a"]
+			"# })?;
+
+			jail.set_env(ENV_CONFIG_FILE, "other-config-file.yaml");
+
+			let config = Config::load()?;
+
+			let mut groups = HashMap::new();
+			groups.insert("bar".into(), GroupConfig {
+				node_selector: Some(vec!["a".into()]),
+				affinity: None,
+				tolerations: None,
+			});
+
+			assert_eq!(config, Config { groups });
+
+			Ok(())
+		});
+	}
+
+	#[test]
+	fn given_value_provided_by_env_then_should_load_value() {
+		Jail::expect_with(|jail| {
+			jail.create_file(DEFAULT_CONFIG_FILE, indoc! { r#"
+				groups:
+				  foo:
+				    affinity: ["x", "y"]
+			"# })?;
+			jail.set_env("PD_GROUPS__FOO__AFFINITY", r#"["a", "b"]"#);
+
+			let config = Config::load()?;
+
+			let mut groups = HashMap::new();
+			groups.insert("foo".into(), GroupConfig {
+				node_selector: None,
+				affinity: Some(vec!["a".into(), "b".into()]),
+				tolerations: None,
+			});
+
+			assert_eq!(config, Config { groups });
+
+			Ok(())
+		});
+	}
+
+	#[test]
+	fn given_value_provided_by_env_and_by_file_then_should_load_value_from_env() {
+		Jail::expect_with(|jail| {
+			jail.set_env("PD_GROUPS__FOO__AFFINITY", r#"["a", "b"]"#);
+
+			let config = Config::load()?;
+
+			let mut groups = HashMap::new();
+			groups.insert("foo".into(), GroupConfig {
+				node_selector: None,
+				affinity: Some(vec!["a".into(), "b".into()]),
+				tolerations: None,
+			});
+
+			assert_eq!(config, Config { groups });
+
+			Ok(())
+		});
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod config;
+
 fn main() {
 	println!("Hello, world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod config;
 
 fn main() {
-	println!("Hello, world!");
+	let config = config::Config::load();
+	println!("Loaded config:");
+	println!("{config:?}");
 }


### PR DESCRIPTION
* Creates the base config module
* The default config file is set to `pd-config.yaml` in the current working directory
* The `PD_CONFIG_FILE` environment variable can be used to override the path, useful during testing
* Every setting can be configured by env var, following the pattern `PD_SETTING__NESTED=value`
  * I am unsure on the double underscore separator. I did it in another project because my settings were snake_case, so it caused problems, but here we should use camelCase, so it's probably unnecessary. I'd like opinions.
* There are tests using Figments' Jail feature. They validate most cases, but for now are dummy tests as the configs are dummy too. We'll need to update them as we introduce features.
* There will be build warnings for unused variables because debug prints don't count as "used code". They'll be used soon enough.

Fixes #2 