### PR TITLE
Custom error handling for mutate

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,13 @@
-use anyhow::{Error, Result};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
+
+use anyhow::{Error, Result};
 use axum_server::tls_rustls::RustlsConfig;
-use figment::{Figment, error, providers::{Env, Format, Yaml}};
+use figment::{error, Figment, providers::{Env, Format, Yaml}};
 use figment::providers::Serialized;
 use serde::{Deserialize, Serialize};
+
 use crate::error::ConfigError;
 
 static ENV_PREFIX: &'static str = "PD_";
@@ -28,7 +30,7 @@ pub enum Conflict {
 	Ignore,
 	Override,
 	#[default]
-	Reject
+	Reject,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]
@@ -93,8 +95,10 @@ pub struct GroupConfig {
 #[cfg(test)]
 mod tests {
 	use std::collections::HashMap;
+
 	use figment::Jail;
 	use indoc::indoc;
+
 	use super::{Config, Conflict, DEFAULT_CONFIG_FILE, ENV_CONFIG_FILE, GroupConfig};
 
 	#[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,3 @@
-use std::path::PathBuf;
-use thiserror::Error;
+mod config;
 
-#[derive(Error, Debug)]
-pub enum ConfigError {
-	#[error("failed loading certificates (cert: \"{cert_path}\"; and key: \"{key_path}\"): {source}")]
-	TlsConfig { source: anyhow::Error, cert_path: PathBuf, key_path: PathBuf }
-}
+pub use config::ConfigError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
 mod config;
+mod response;
 
 pub use config::ConfigError;
+pub use response::ResponseError;

--- a/src/error/config.rs
+++ b/src/error/config.rs
@@ -1,0 +1,8 @@
+use thiserror::Error;
+use std::path::PathBuf;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+	#[error("failed loading certificates (cert: \"{cert_path}\"; and key: \"{key_path}\"): {source}")]
+	TlsConfig { source: anyhow::Error, cert_path: PathBuf, key_path: PathBuf }
+}

--- a/src/error/response.rs
+++ b/src/error/response.rs
@@ -1,0 +1,55 @@
+use axum::http::StatusCode;
+use axum::Json;
+use axum::response::{IntoResponse, Response};
+use k8s_openapi::api::core::v1::Pod;
+use kube::core::admission::{AdmissionRequest, AdmissionResponse, ConvertAdmissionReviewError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ResponseError {
+	#[error("Failed converting request into AdmissionRequest for Pod: {0}")]
+	ParseAdmission(#[from] ConvertAdmissionReviewError),
+
+	#[error("Pod has no namespace defined (this is unexpected)")]
+	NoNamespace,
+
+	#[error(transparent)]
+	KubernetesApi(#[from] kube::error::Error),
+
+	#[error("processed pod's namespace {0} doesn't contain a pod-director group label, the MutatingWebhookConfiguration is probably misconfigured", request.namespace.as_ref().unwrap_or(& "unknown".into()))]
+	NamespaceMissingLabel { request: AdmissionRequest<Pod> },
+
+	#[error("No pod-director group configured with the name {group}, the namespace {0} is misconfigured", request.namespace.as_ref().unwrap_or(& "unknown".into()))]
+	MissingGroupConfig { request: AdmissionRequest<Pod>, group: String },
+}
+
+impl IntoResponse for ResponseError {
+	fn into_response(self) -> Response {
+		match self {
+			ResponseError::ParseAdmission(_) => (
+				StatusCode::BAD_REQUEST,
+				Json(AdmissionResponse::invalid(&self).into_review())
+			),
+			ResponseError::NoNamespace => (
+				StatusCode::BAD_REQUEST,
+				Json(AdmissionResponse::invalid(&self).into_review())
+			),
+			ResponseError::KubernetesApi(_) => (
+				StatusCode::INTERNAL_SERVER_ERROR,
+				Json(AdmissionResponse::invalid(&self).into_review())
+			),
+			ResponseError::NamespaceMissingLabel { ref request } => {
+				let mut response = AdmissionResponse::from(request);
+				response.warnings = Some(vec![self.to_string()]);
+				(
+					StatusCode::OK,
+					Json(response.into_review())
+				)
+			}
+			ResponseError::MissingGroupConfig { ref request, .. } => (
+				StatusCode::OK,
+				Json(AdmissionResponse::from(request).deny(self.to_string()).into_review())
+			),
+		}.into_response()
+	}
+}

--- a/src/handler/mutate.rs
+++ b/src/handler/mutate.rs
@@ -6,7 +6,7 @@ use k8s_openapi::api::core::v1::Pod;
 use kube::core::admission::{AdmissionRequest, AdmissionResponse, AdmissionReview};
 
 use crate::server::AppState;
-use crate::service::kubernetes::KubernetesService;
+use crate::service::KubernetesService;
 use crate::utils::patch;
 use crate::utils::patch::PatchResult;
 

--- a/src/handler/mutate.rs
+++ b/src/handler/mutate.rs
@@ -1,10 +1,11 @@
 use axum::extract::State;
-use axum::http::StatusCode;
 use axum::Json;
-use axum::response::IntoResponse;
+use axum::response::Result;
 use k8s_openapi::api::core::v1::Pod;
+use kube::api::DynamicObject;
 use kube::core::admission::{AdmissionRequest, AdmissionResponse, AdmissionReview};
 
+use crate::error::ResponseError;
 use crate::server::AppState;
 use crate::service::KubernetesService;
 use crate::utils::patch;
@@ -13,66 +14,27 @@ use crate::utils::patch::PatchResult;
 pub async fn mutate<S: AppState>(
 	State(app_state): State<S>,
 	Json(body): Json<AdmissionReview<Pod>>,
-) -> impl IntoResponse {
-	let request: AdmissionRequest<Pod> = match body.try_into() {
-		Err(err) => {
-			// TODO: Should probably have a custom error return
-			println!("Bad request");
-			return (
-				StatusCode::BAD_REQUEST,
-				Json(AdmissionResponse::invalid(err).into_review()),
-			);
-		}
-		Ok(v) => v,
+) -> Result<Json<AdmissionReview<DynamicObject>>, ResponseError> {
+	let request: AdmissionRequest<Pod> = body.try_into()?;
+
+	let namespace = request.namespace.as_ref().ok_or(ResponseError::NoNamespace)?;
+
+	let group = match app_state.kubernetes().namespace_group(namespace).await? {
+		Some(g) => g,
+		None => return Err(ResponseError::NamespaceMissingLabel {
+			request,
+		}),
 	};
 
-	let namespace = match request.namespace {
-		None => {
-			return (
-				StatusCode::OK,
-				Json(
-					AdmissionResponse::invalid("Pod has no namespace defined (this is unexpected)")
-						.into_review(),
-				),
-			);
-		}
-		Some(ref v) => v,
-	};
-
-	let group = match app_state.kubernetes().namespace_group(namespace).await {
-		Err(err) => {
-			// TODO: Should probably have a custom error return
-			println!("Couldn't get namespace: {err:?}");
-			return (
-				StatusCode::INTERNAL_SERVER_ERROR,
-				Json(AdmissionResponse::from(&request).into_review()),
-			);
-		}
-		Ok(v) => match v {
-			None => {
-				let warning = format!("processed pod's namespace {namespace} doesn't contain a pod-director group label, the MutatingWebhookConfiguration is probably misconfigured");
-				let mut response = AdmissionResponse::from(&request);
-				response.warnings = Some(vec![warning]);
-				return (StatusCode::OK, Json(response.into_review()));
-			}
-			Some(g) => g,
-		},
+	let group_config = match app_state.config().groups.get(&group) {
+		Some(group_config) => group_config,
+		None => return Err(ResponseError::MissingGroupConfig {
+			request,
+			group,
+		}),
 	};
 
 	let mut patches = Vec::new();
-	let group_config = match app_state.config().groups.get(&group) {
-		None => {
-			let reason = format!(
-				"No pod-director group configured with the name {group}, the namespace {namespace} is misconfigured"
-			);
-			return (
-				StatusCode::OK,
-				Json(AdmissionResponse::from(&request).deny(reason).into_review()),
-			);
-		}
-		Some(group_config) => group_config,
-	};
-
 	if let Some(node_selector_config) = &group_config.node_selector {
 		let node_selector_patches = patch::calculate_node_selector_patches(
 			request.object.as_ref().expect("Request object is missing"),
@@ -82,31 +44,21 @@ pub async fn mutate<S: AppState>(
 
 		match node_selector_patches {
 			PatchResult::Allow(v) => patches.extend(v),
-			PatchResult::Deny {
-				label,
-				config_value,
-				conflicting_value,
-			} => {
+			PatchResult::Deny { label, config_value, conflicting_value } => {
 				let reason = format!(
 					"The pod's nodeSelector {label}={conflicting_value} conflicts with pod-director's configuration {label}={config_value}"
 				);
-				return (
-					StatusCode::OK,
-					Json(AdmissionResponse::from(&request).deny(reason).into_review()),
-				);
+				return Ok(Json(AdmissionResponse::from(&request).deny(reason).into_review()));
 			}
 		}
 	}
 
-	(
-		StatusCode::OK,
-		Json(
-			AdmissionResponse::from(&request)
-				.with_patch(json_patch::Patch(patches))
-				.unwrap()
-				.into_review(),
-		),
-	)
+	Ok(Json(
+		AdmissionResponse::from(&request)
+			.with_patch(json_patch::Patch(patches))
+			.unwrap()
+			.into_review(),
+	))
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,8 @@ use crate::config::Config;
 use super::handler;
 
 pub use state::{AppState, StandardAppState};
-use crate::service::kubernetes::StandardKubernetesService;
+
+use crate::service::StandardKubernetesService;
 
 mod tls;
 mod shutdown;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use crate::config::Config;
-use crate::service::kubernetes::{KubernetesService, StandardKubernetesService};
+use crate::service::{KubernetesService, StandardKubernetesService};
 
 pub trait AppState: Clone + Send + Sync + 'static {
 	type K: KubernetesService;
@@ -38,7 +38,7 @@ pub mod tests {
 	use std::sync::Arc;
 	use crate::config::Config;
 	use crate::server::AppState;
-	use crate::service::kubernetes::tests::MockKubernetesService;
+	use crate::service::tests::MockKubernetesService;
 
 	#[derive(Clone)]
 	pub struct TestAppState {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,1 +1,6 @@
-pub mod kubernetes;
+mod kubernetes;
+
+pub use kubernetes::{KubernetesService, StandardKubernetesService};
+
+#[cfg(test)]
+pub use kubernetes::tests;


### PR DESCRIPTION
- Adjusts some exports on Service to be more consistent with the rest of the project
- Extracts ConfigError to its own submodule
- Extracts mutate's error handling to custom errors

Closes #20 