### PR TITLE
Add base Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+/**/output/
+/**/charts/
+!/charts/

--- a/charts/pod-director/.helmignore
+++ b/charts/pod-director/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/pod-director/Chart.yaml
+++ b/charts/pod-director/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: pod-director
+description: A simple utility to make pods in specific namespaces run in specific nodes
+type: application
+version: 0.1.0

--- a/charts/pod-director/templates/NOTES.txt
+++ b/charts/pod-director/templates/NOTES.txt
@@ -1,0 +1,14 @@
+{{- if .Values.config.groups }}
+Pod Director installed, the following groups were configured:
+{{- toYaml .Values.config.groups | nindent 2 }}
+
+{{ $firstGroup := first (keys .Values.config.groups) -}}
+{{ $testNamespace := "test-namespace" -}}
+You can validate that the groups are working by labelling a test namespace with a group and running a pod in it:
+  kubectl create namespace {{ $testNamespace }}
+  kubectl label namespace {{ $testNamespace }} pod-director/group={{ $firstGroup }}
+  kubectl -n {{ $testNamespace }} run --rm -ti --image=busybox -- /bin/sh
+{{- else }}
+Pod Director was installed, but no groups were configured! It will remain idle until you configure a group and label
+a namespace!
+{{- end }}

--- a/charts/pod-director/templates/_helpers.tpl
+++ b/charts/pod-director/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{- define "pod-director.name" -}}
+  {{- .Values.nameOverride | default .Chart.Name  | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "pod-director.fullname" -}}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := .Values.nameOverride | default .Chart.Name  }}
+    {{- if .Release.Name | contains $name  }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "pod-director.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "pod-director.labels" -}}
+{{- include "pod-director.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "pod-director.chart" . }}
+{{- with .Values.globalLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "pod-director.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pod-director.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "pod-director.serviceAccountName" -}}
+  {{- .Values.serviceAccount.name | default (include "pod-director.fullname" .)  }}
+{{- end }}
+
+{{- define "pod-director.imageFullname" -}}
+  {{- $image := .Values.image }}
+  {{- $registry := $image.registry }}
+  {{- $repository := required "An repository is required" $image.repository }}
+  {{- $tag := $image.tag | default .Chart.Version }}
+  {{- if $registry }}
+    {{- $registry = print $registry "/" }}
+  {{- end }}
+  {{- if $tag }}
+    {{- $tag = print ":" $tag }}
+  {{- end }}
+  {{- print $registry $repository $tag }}
+{{- end }}
+
+{{- define "pod-director.configMapName" -}}
+  {{- include "pod-director.fullname" . }}
+{{- end }}
+
+{{- define "pod-director.serviceName" -}}
+  {{- include "pod-director.fullname" . }}
+{{- end }}
+
+{{- define "pod-director.webhookSecretName" -}}
+  {{- include "pod-director.fullname" . }}
+{{- end }}
+
+{{- define "pod-director.clusterRoleName" -}}
+  {{- include "pod-director.fullname" . }}
+{{- end }}

--- a/charts/pod-director/templates/clusterrole.yaml
+++ b/charts/pod-director/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "pod-director.clusterRoleName" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]

--- a/charts/pod-director/templates/configmap.yaml
+++ b/charts/pod-director/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pod-director.configMapName" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+  {{- with .Values.config.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{ .Values.config.filename | quote }}: |
+    server:
+      {{- toYaml .Values.config.server | nindent 6 }}
+    groups:
+      {{- toYaml .Values.config.groups | nindent 6 }}

--- a/charts/pod-director/templates/deployment.yaml
+++ b/charts/pod-director/templates/deployment.yaml
@@ -1,0 +1,101 @@
+{{- $configMountPath := without (splitList "/" .Values.config.mountPath) "" | join "/" | printf "/%s" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pod-director.fullname" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pod-director.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "pod-director.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      serviceAccountName: {{ include "pod-director.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      containers:
+        - name: pod-director
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "pod-director.imageFullname" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PD_CONFIG_FILE
+              value: {{ print $configMountPath "/" .Values.config.filename | quote }}
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.server.port | default 8443 }}
+              protocol: TCP
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+              scheme: {{ .Values.readinessProbe.scheme }}
+            periodSeconds: {{ .Values.readinessProbe.period }}
+            successThreshold: {{ .Values.readinessProbe.successCount }}
+            failureThreshold: {{ .Values.readinessProbe.failureCount }}
+            {{- if .Values.readinessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          volumeMounts:
+            - name: pd-config
+              mountPath: {{ $configMountPath }}
+              readOnly: true
+            - name: webhook
+              mountPath: /app/certs
+              readOnly: true
+            {{- with .Values.volumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: pd-config
+          configMap:
+            name: {{ include "pod-director.configMapName" . }}
+        - name: webhook
+          secret:
+            secretName: {{ include "pod-director.webhookSecretName" . }}
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}

--- a/charts/pod-director/templates/hpa.yaml
+++ b/charts/pod-director/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "pod-director.fullname" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+  {{- with .Values.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "pod-director.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+{{- end }}

--- a/charts/pod-director/templates/ingress.yaml
+++ b/charts/pod-director/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "pod-director.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/pod-director/templates/pdb.yaml
+++ b/charts/pod-director/templates/pdb.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.pdb.enabled }}
+  {{- if or (and .Values.pdb.minAvailable .Values.pdb.maxUnavailable) (and (not .Values.pdb.minAvailable) (not .Values.pdb.maxUnavailable)) }}
+    {{- fail "Either minAvailable or maxUnavailable for PDB must be defined (but not both)" }}
+  {{- end }}
+
+  {{- if .Values.autoscaling.enabled }}
+    {{- if le (int .Values.autoscaling.minReplicas) 1 }}
+      {{- fail "To use a PDB with autoscaling, minReplicas must be greater than 1" }}
+    {{- end }}
+  {{- else if le (int .Values.replicaCount) 1 }}
+    {{- fail "To use a PDB with a static replica count, replicaCount must be greater than 1" }}
+  {{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pod-director.fullname" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+  {{- with .Values.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pod-director.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/pod-director/templates/rolebinding.yaml
+++ b/charts/pod-director/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "pod-director.fullname" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "pod-director.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "pod-director.clusterRoleName" . }}

--- a/charts/pod-director/templates/service.yaml
+++ b/charts/pod-director/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pod-director.serviceName" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "pod-director.selectorLabels" . | nindent 4 }}

--- a/charts/pod-director/templates/serviceaccount.yaml
+++ b/charts/pod-director/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pod-director.serviceAccountName" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true

--- a/charts/pod-director/templates/webhooks.yaml
+++ b/charts/pod-director/templates/webhooks.yaml
@@ -1,0 +1,42 @@
+{{- $ca := genCA "pod-director-ca" 30 -}}
+{{- $serviceFqdn := printf "%s.%s.svc" (include "pod-director.serviceName" .) .Release.Namespace -}}
+{{- $cert := genSignedCert $serviceFqdn nil (list (include "pod-director.serviceName" .) $serviceFqdn) 30 $ca -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "pod-director.webhookSecretName" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+data:
+  tls.crt: {{ $cert.Cert | toString | b64enc }}
+  tls.key: {{ $cert.Key | toString | b64enc }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "pod-director.fullname" . }}
+  labels:
+    {{- include "pod-director.labels" . | nindent 4 }}
+webhooks:
+  - name: {{ $serviceFqdn }}
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      caBundle: {{ $ca.Cert | toString | b64enc }}
+      service:
+        name: {{ include "pod-director.serviceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate"
+        port: {{ .Values.service.port }}
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: pod-director/group
+          operator: Exists
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        scope: "Namespaced"
+    sideEffects: None

--- a/charts/pod-director/tests/deployment_test.yaml
+++ b/charts/pod-director/tests/deployment_test.yaml
@@ -1,0 +1,128 @@
+suite: deployment tests
+
+templates:
+  - deployment.yaml
+
+tests:
+  - it: given disabled autoscaling then deployment should be configured with replicas
+    set:
+      autoscaling:
+        enabled: false
+      replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+  - it: given enabled autoscaling then deployment should not contain replicas
+    set:
+      autoscaling:
+        enabled: true
+      replicaCount: 2
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: given custom pod labels then should include them along default labels
+    release:
+      name: pod-director
+    set:
+      podLabels:
+        foo: bar
+        bazz: banana
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["foo"]
+          value: bar
+      - equal:
+          path: spec.template.metadata.labels["bazz"]
+          value: banana
+
+  - it: given a configured mountPath then mountPath is sanitized
+    set:
+      config:
+        mountPath: foo//bar/
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            mountPath: /foo/bar
+            readOnly: true
+
+  - it: given a configured mountPath and file name then PD_CONFIG_FILE env var is set to absolute path
+    set:
+      config:
+        mountPath: /foo/bar
+        filename: name.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PD_CONFIG_FILE
+            value: /foo/bar/name.yaml
+
+  - it: given extra pod labels should include them along default labels
+    release:
+      name: release-name
+    chart:
+      version: 1.2.3
+    set:
+      podLabels:
+        foo: value
+        bar: other-value
+      nameOverride: name-override
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/version"]
+          value: 1.2.3
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: spec.template.metadata.labels["helm.sh/chart"]
+          value: pod-director-1.2.3
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: name-override
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: release-name
+      - equal:
+          path: spec.template.metadata.labels["foo"]
+          value: value
+      - equal:
+          path: spec.template.metadata.labels["bar"]
+          value: other-value
+
+  - it: given extra envs should configure them along default envs
+    set:
+      config:
+        mountPath: /foo/bar
+        filename: name.yaml
+      env:
+        - name: FOO
+          value: bar
+        - name: SECRET
+          valueFrom:
+            secretKeyRef:
+              name: some-secret
+              key: some-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PD_CONFIG_FILE
+            value: /foo/bar/name.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FOO
+            value: bar
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SECRET
+            valueFrom:
+              secretKeyRef:
+                name: some-secret
+                key: some-key

--- a/charts/pod-director/tests/global_test.yaml
+++ b/charts/pod-director/tests/global_test.yaml
@@ -1,0 +1,33 @@
+suite: global tests
+
+templates:
+  - configmap.yaml
+  - deployment.yaml
+  - hpa.yaml
+  - ingress.yaml
+  - pdb.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - rolebinding.yaml
+
+tests:
+  - it: given configured global labels then all resources should have global labels
+    set:
+      ingress:
+        enabled: true
+      autoscaling:
+        enabled: true
+      pdb:
+        enabled: true
+        minAvailable: 1
+      globalLabels:
+        foo: value
+        bar: other-value
+    asserts:
+      - equal:
+          path: metadata.labels["foo"]
+          value: value
+      - equal:
+          path: metadata.labels["bar"]
+          value: other-value

--- a/charts/pod-director/tests/pdb_test.yaml
+++ b/charts/pod-director/tests/pdb_test.yaml
@@ -1,0 +1,66 @@
+suite: pdb test
+
+templates:
+  - pdb.yaml
+
+tests:
+  - it: given enabled pdb then either minAvailable or maxUnavailable must be defined
+    set:
+      pdb:
+        enabled: true
+        minAvailable: null
+        maxUnavailable: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "Either minAvailable or maxUnavailable for PDB must be defined (but not both)"
+  - it: given enabled pdb then both minAvailable or maxUnavailable must not be defined together
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: "50%"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Either minAvailable or maxUnavailable for PDB must be defined (but not both)"
+
+  - it: given enabled pdb and disabled autoscaling then replicaCount must be greater than 1
+    set:
+      replicaCount: 1
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "To use a PDB with a static replica count, replicaCount must be greater than 1"
+  - it: given enabled pdb and enabled autoscaling then autoscaling minAvailable must be greater than 1
+    set:
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "To use a PDB with autoscaling, minReplicas must be greater than 1"
+
+  - it: given enabled pdb and disabled autoscaling and replicaCount greater than 1 then must create pdb
+    set:
+      replicaCount: 2
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: given enabled pdb and enabled autoscaling and autoscaling minAvailable greater than 1 then must create pdb
+    set:
+      autoscaling:
+        enabled: true
+        minReplicas: 2
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/pod-director/values.yaml
+++ b/charts/pod-director/values.yaml
@@ -1,0 +1,259 @@
+# Overrides the chart name
+nameOverride: ""
+# Overrides the full release name
+fullnameOverride: ""
+
+image:
+  registry: todo  # You can override the registry, useful if you are using some kind of container cache
+  repository: pod-director
+  tag: ""  # Overrides the image tag whose default is the chart appVersion.
+  pullPolicy: IfNotPresent  # See Kubernetes' pull policy
+  pullSecrets: []  # See pull secrets
+
+# Pod director's configuration
+config:
+  # Annotations to add to the ConfigMap
+  annotations: {}
+
+  # Mount path and filename to mount in the container
+  # Generally, unless you have very specific requirements for what is being mounted in the container, or are using some
+  # kind of sidecar or init container, this doesn't need to be changed
+  mountPath: /app/config
+  filename: pd-config.yaml
+
+  # Main group config for pod director! See the documentation <here> TODO
+  groups: {}
+  #  cicd:
+  #    nodeSelector:
+  #      role: "cicd"
+  #    tolerations:
+  #      - key: role
+  #        operator: Equals
+  #        value: cicd
+  #        effect: NoSchedule
+  #  windows:
+  #    nodeSelector:
+  #      kubernetes.io/os: "windows"
+
+  # Server configs, generally they do not need to be changed unless you have very specific requirements
+  server: {}
+  #  bind_addr: 0.0.0.0
+  #  port: 8443
+  #  insecure: false
+  #  cert: certs/cert.pem
+  #  key: certs/key.pem
+
+# Number of Pod Director's replicas to run, ignored if autoscaling is enabled
+replicaCount: 1
+
+autoscaling:
+  # Enables or disables autoscaling for Pod Director
+  enabled: false
+
+  # Extra annotations to add to the HPA
+  annotations: {}
+
+  # Minimum and maximum number of replicas to run, use a minimum of 2 for High Availability
+  minReplicas: 2
+  maxReplicas: 5
+
+  # Both metrics and behavior are highly customizable and dependent on your use case, check Kubernetes' HPA
+  # documentation for possible values, simply using the examples below is unlikely to be productive
+  metrics:
+  # - type: Resource
+  #   resource:
+  #     name: cpu
+  #     target:
+  #       type: Utilization
+  #       averageUtilization: 80
+  # - type: Resource
+  #   resource:
+  #     name: memory
+  #     target:
+  #       type: Utilization
+  #       averageUtilization: 80
+  behavior:
+  # scaleUp:
+  #   stabilizationWindowSeconds: 120
+  #   policies:
+  #     - type: Percent
+  #       value: 50
+  #       periodSeconds: 60
+  # scaleDown:
+  #   stabilizationWindowSeconds: 300
+  #   policies:
+  #     - type: Pods
+  #       value: 1
+  #       periodSeconds: 30
+
+# Pod Director generally uses <TODO> memory per container
+# Due to local caching, estimate <TODO> extra per namespace in your cluster
+resources: {}
+# limits:
+#   cpu: 50m
+#   memory: 64Mi
+# requests:
+#   cpu: 50m
+#   memory: 64Mi
+
+# Pod Director requires permissions to list and watch cluster Namespaces
+# It will only interact with Namespaces labeled correctly
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set, a name is generated using the fullname template
+  name: ""
+
+# Map envs to the main container directly
+env: []
+
+# Map extra environment variables to the main container from configmaps or secrets
+envFrom: []
+
+# Service to expose to the cluster
+service:
+  annotations: {}
+  type: ClusterIP
+
+  # Note that Kubernetes' API expects to call a HTTPS endpoint for its webhooks
+  # In most use cases, you can't terminate TLS anywhere but directly at the service
+  port: 443
+
+# Generally, it's not useful to expose Pod Director outside the cluster, and it is not required for standard operation
+# Nonetheless, the Ingress is available in case you want to monitor the health endpoint or collect metrics from outside
+# the cluster
+ingress:
+  enabled: false
+  className: ""  # Selects the appropriate Ingress Controller
+
+  # Extra annotations to add to the Ingress
+  annotations: {}
+
+  # Standard Ingress configuration for hosts and TLS
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Determines availability of the applications and guarantees that the cluster won't evict too many pods
+# minAvailable and maxUnavailable are mutually exclusive, you must configure only one
+# To have this enabled, replicas must be > 1 or autoscaling minReplicas must be > 1
+pdb:
+  # Extra annotations to add to the PDB
+  annotations: {}
+  enabled: false
+  # minAvailable: 1  # Minimum number of available pods
+  # maxUnavailable: "50%"  # Maximum number of pods that can be evicted
+
+# Update strategy, mapped directly to the Deployment's update strategy
+updateStrategy:
+  # Type of update strategy, can be either "RollingUpdate", for smooth transitions, or "Recreate", to destroy
+  # pods before starting new ones
+  type: RollingUpdate
+
+  # If using rolling update, you can configure the maximum surge (pods above the limit) or maximum unavailable pods
+  # during rollout. Both can be an absolute number or a percentage. See the Kubernetes' docs for more information
+  # rollingUpdate:
+  #   maxSurge: 50%
+  #   maxUnavailable: 2
+
+# Maps directly to the Pod's security context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# Main container's security context, Pod Director requires no special privileges
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Main container's lifecycle
+lifecycle: {}
+# postStart:
+#   exec:
+#     command: ["echo", "Hello"]
+# preStop:
+#   exec:
+#     command: ["echo", "Bye"]
+
+# Default readiness probe, generally you do not need to change this
+readinessProbe:
+  enabled: true
+  # HTTP path to check
+  path: /health
+  # Since Kubernetes' requires that admission webhooks be HTTPS endpoints, the healthcheck also uses HTTPS
+  scheme: HTTPS
+  # Period in seconds between checks
+  period: 5
+  # The check has to succeed this many times before the pod is considered ready
+  successCount: 1
+  # The check has to fail this many times before the pod is considered not ready
+  failureCount: 3
+  # Delay in seconds before sending probes, generally this is not needed
+  initialDelaySeconds:
+
+# Extra labels to add to ALL resources from this chart
+globalLabels: {}
+
+# Extra annotations to add to the pods
+podAnnotations: {}
+
+# Extra labels to add to the pods
+podLabels: {}
+
+# List of init containers to add to the pods, mapped directly to the Deployment's initContainers
+initContainers: []
+#  - name: my-init
+#    image: busybox
+#    command: ["foo", "bar"]
+
+# List of extra containers (sidecars) to add to the deployment
+extraContainers: []
+#  - name: my-sidecar
+#    image: busybox
+#    command: ["foo", "bar"]
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+# Maps directly to the pods' node selector
+nodeSelector: {}
+# foo: bar
+
+# Maps directly to the pods' tolerations
+tolerations: []
+#  - key: "foo"
+#    operator: "Equal"
+#    value: "bar"
+#    effect: "NoSchedule"
+
+# Maps directly to the pods' affinity, use pod anti affinity for high availability
+affinity: {}
+#  podAntiAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      - labelSelector:
+#          matchExpressions:
+#            - key: app.kubernetes.io/instance
+#              operator: In
+#              values: ["pod-director"]
+#        topologyKey: "kubernetes.io/hostname"

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,8 +77,8 @@ impl Default for ServerConfig {
 			bind_addr: IpAddr::from([0, 0, 0, 0]),
 			port: 8443,
 			insecure: false,
-			cert: PathBuf::from("cert.pem"),
-			key: PathBuf::from("key.pem"),
+			cert: PathBuf::from("certs/cert.pem"),
+			key: PathBuf::from("certs/key.pem"),
 		}
 	}
 }


### PR DESCRIPTION
- Adds a Helm Chart with:
  - Base deployment, service and webhook, and appropriate role bindings
  - Ingress, in case the endpoint needs exposing (not really useful now, maybe later with metrics)
  - HPA
  - PDB
  - Notes
- Adds some test coverage